### PR TITLE
Fix hybrid masking pattern selection

### DIFF
--- a/MSP1_hybrid.jsx
+++ b/MSP1_hybrid.jsx
@@ -127,8 +127,13 @@ var MSP_preserveStrokes = $.global.MSP_preserveStrokes;
             
             // Paste pattern
             app.activeDocument = docPattern;
-            docPattern.selectObjectsOnActiveArtboard();
-            app.copy();
+            // Unlock all items to ensure complete selection
+            for (var n = 0; n < docPattern.pageItems.length; n++) {
+                unlockDeep(docPattern.pageItems[n]);
+            }
+            // Select everything rather than just the active artboard
+            app.executeMenuCommand("selectall");
+            app.executeMenuCommand("copy");
             
             app.activeDocument = docMask;
             app.paste();


### PR DESCRIPTION
## Summary
- unlock all items when copying pattern in `MSP1_hybrid.jsx`
- use `selectall` instead of `selectObjectsOnActiveArtboard` so nothing is omitted

## Testing
- `node -e "require('fs').accessSync('MSP1_hybrid.jsx'); console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_b_683a7174b99c8326bac2052b67a91d4f